### PR TITLE
Use correct health endpoints

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -222,7 +222,7 @@ spec:
             containerPort: 8080
         livenessProbe:
           httpGet:
-            path: /
+            path: /health
             port: http
             httpHeaders:
               - name: X-probe
@@ -232,7 +232,7 @@ spec:
           timeoutSeconds: 10
         readinessProbe:
           httpGet:
-            path: /
+            path: /health/status
             port: http
             httpHeaders:
               - name: X-probe


### PR DESCRIPTION
The readiness and liveness probes were previously set to /.
This meant that the probes failed, as the route / needs authentication.

The management-ui already has endpoints for both liveness and readiness,
so this commit points the probes at the correct endpoints.

The liveness probe on the management-ui checks to see if the
management-ui itself is ready to run. If the liveness check fails, then
Kubernetes will make the pod restart.

The readiness probe is a bit more complicated. Kubernetes won't restart
if the readiness probe fails, but it won't direct traffic towards the
pod until it does. The management-ui currently checks to see if it can
connect to all the relevant upstream APIs before returning a successful
readiness check.