### PR TITLE
HOCS-1746 Use ACP Quay.io proxy

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: certs
-        image: quay.io/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.6
+        image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/cfssl-sidekick-jks:v0.0.6
         securityContext:
           runAsNonRoot: true
           capabilities:
@@ -56,7 +56,7 @@ spec:
             cpu: 300m
 
       - name: proxy
-        image: quay.io/ukhomeofficedigital/nginx-proxy-govuk:v3.4.12
+        image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/nginx-proxy-govuk:v3.4.12
         imagePullPolicy: Always
         securityContext:
           runAsNonRoot: true
@@ -105,7 +105,7 @@ spec:
             cpu: 100m
 
       - name: keycloak-proxy-web
-        image: quay.io/keycloak/keycloak-gatekeeper:8.0.2
+        image: quay.digital.homeoffice.gov.uk/keycloak/keycloak-gatekeeper:8.0.2
         imagePullPolicy: Always
         securityContext:
           runAsNonRoot: true
@@ -156,7 +156,7 @@ spec:
             cpu: 100m
 
       - name: keycloak-proxy-api
-        image: quay.io/keycloak/keycloak-gatekeeper:8.0.2
+        image: quay.digital.homeoffice.gov.uk/keycloak/keycloak-gatekeeper:8.0.2
         imagePullPolicy: Always
         securityContext:
           runAsNonRoot: true
@@ -205,7 +205,7 @@ spec:
             cpu: 100m
 
       - name: hocs-management-ui
-        image: quay.io/ukhomeofficedigital/hocs-management-ui:{{.VERSION}}
+        image: quay.digital.homeoffice.gov.uk/ukhomeofficedigital/hocs-management-ui:{{.VERSION}}
         imagePullPolicy: Always
         securityContext:
           runAsNonRoot: true


### PR DESCRIPTION
This commit changes references to Quay.io to a Home Office hosted proxy
of Quay.io. This will mean that if Quay.io is unavailable, previously
pulled images will still be available for download. However, it would
still not be possible to push new images, which must go to Quay
directly.

This merely moves the single point of failure, but to one that is within
the Home Office's responsibility and therefore might be easier to fix.

If the ACP mirror goes down, you can revert this commit without
consequence.