### PR TITLE
HOCS-2097 Autoscale Replicas

### DIFF
--- a/kd/autoscale.yaml
+++ b/kd/autoscale.yaml
@@ -5,10 +5,10 @@ metadata:
     app: hocs-management-ui
   name: hocs-management-ui
 spec:
-  maxReplicas: 10
-  minReplicas: 1
+  maxReplicas: 2
+  minReplicas: {{.REPLICAS}}
   scaleTargetRef:
     apiVersion: apps/v1
     kind: Deployment
     name: hocs-management-ui
-  targetCPUUtilizationPercentage: 10
+  targetCPUUtilizationPercentage: 24


### PR DESCRIPTION
The minimum instances for a given target environment is set in the deploy script. Using this value to set the default number of minimum instances for the service.
Also amended the max number and the target percentage, which were incorrect.