### PR TITLE
HOCS-1983 Add redirect URL env var

### DIFF
--- a/kd/deployment.yaml
+++ b/kd/deployment.yaml
@@ -289,6 +289,8 @@ spec:
             value: 'https://hocs-info-service.{{.KUBE_NAMESPACE}}.svc.cluster.local'
           - name: OUTBOUND_PROXY
             value: 'http://hocs-outbound-proxy.{{.KUBE_NAMESPACE}}.svc.cluster.local:31290'
+          - name: LOGOUT_REDIRECT_URL
+            value: https://{{.DOMAIN_NAME}}
           - name: ALLOWED_FILE_EXTENSIONS
             valueFrom:
               configMapKeyRef:


### PR DESCRIPTION
This allows us to tweak where the logout link sends us once Keycloak
logs users out.